### PR TITLE
Resolve @svgr/webpack relative to next-svgr

### DIFF
--- a/src/withSvg.js
+++ b/src/withSvg.js
@@ -3,7 +3,7 @@ const withSvg = (nextConfig = {}, nextComposePlugins = {}) => {
     webpack(config, options) {
       config.module.rules.push({
         test: /\.svg$/,
-        use: ["@svgr/webpack"]
+        use: [require.resolve("@svgr/webpack")]
       });
 
       if (typeof nextConfig.webpack === "function") {


### PR DESCRIPTION
Previously, webpack would attempt to resolve @svgr/webpack relative to
the Next.js project, which would result in an error like this using
strict package managers like pnpm / Yarn PnP:

    Module not found: Can't resolve '@svgr/webpack' in '/path/to/project'

Using `require.resolve()` fixes this.